### PR TITLE
feature/Add funcionalidade botoes like e deslike

### DIFF
--- a/MediaVirtu/src/data/shitposts.json
+++ b/MediaVirtu/src/data/shitposts.json
@@ -14,7 +14,9 @@
 
         "likes" : 10,
 
-        "dislikes" : 37
+        "dislikes" : 37,
+
+        "codigo_post" : "qHMElv3JCyGoFHjAfApl"
     },
 
     {
@@ -33,7 +35,9 @@
 
         "likes" : 139,
 
-        "dislikes" : 15
+        "dislikes" : 15,
+
+        "codigo_post" : "3fG3Knwlg4FL4pa7voAp"
     },
 
     {
@@ -51,7 +55,9 @@
 
         "likes" : 365,
 
-        "dislikes" : 80
+        "dislikes" : 80,
+
+        "codigo_post" : "2m34hF9kV4t2CgCuTtPj"
     },
 
     {
@@ -69,7 +75,9 @@
 
         "likes" : 24,
 
-        "dislikes" : 1
+        "dislikes" : 1,
+
+        "codigo_post" : "Hj9BFXhDCRv5zxzd5TF1"
     },
 
     {
@@ -87,7 +95,9 @@
 
         "likes" : 456,
 
-        "dislikes" : 56
+        "dislikes" : 56,
+
+        "codigo_post" : "aggIwCPIVaL0JBvAIy4x"
     },
 
     {
@@ -105,6 +115,8 @@
       
         "likes" : 973,
       
-        "dislikes" : 0
+        "dislikes" : 0,
+
+        "codigo_post" : "OCxQQOLSmFwzHVlYNyUg"
     }
 ]

--- a/MediaVirtu/src/javascript/gerador_aleatorio.js
+++ b/MediaVirtu/src/javascript/gerador_aleatorio.js
@@ -1,0 +1,12 @@
+export default function gerarCodigoAleatorio(tamanho) {
+    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    let codigo = '';
+    const array = new Array(tamanho).fill(0);
+    const tamanho_characters = characters.length;
+
+    array.forEach((_) => {
+        codigo += characters.charAt(Math.floor(Math.random() * tamanho_characters));
+    });
+
+  return codigo;
+}

--- a/MediaVirtu/src/javascript/inicio.js
+++ b/MediaVirtu/src/javascript/inicio.js
@@ -14,7 +14,8 @@ export default function inicio () {
             post.texto,
             post.imagens,
             post.likes,
-            post.dislikes
+            post.dislikes,
+            post.codigo_post
         ) +
         linha_divisora()
 

--- a/MediaVirtu/src/javascript/likes_dislikes.js
+++ b/MediaVirtu/src/javascript/likes_dislikes.js
@@ -1,0 +1,105 @@
+export default function addLikesDislikesEventos () {
+    const feed = document.querySelector("#corpo-principal");
+
+    likeEvento(feed);
+    dislikeEvento(feed);
+}
+
+/*dar like*/
+function likeEvento (feed) {
+    feed.addEventListener("click", (event) => {
+        const botao_gostei = event.target.closest(".botao-gostei");
+        
+        if (!botao_gostei) return;
+        
+        /*dados importantes do próprio botão de like*/
+        const codigo_post = botao_gostei.id.slice(5);
+        const icone_gostei = botao_gostei.querySelector(`.icone-gostei`);
+        const qtd_likes = botao_gostei.querySelector(`#qtd-likes-${ codigo_post }`);
+        const lista_likes = JSON.parse(localStorage.getItem("lista_likes") || "[]");
+
+        /*dados do botão de dislike*/
+        const icone_naogostei = document.querySelector(`#post-${ codigo_post } .icone-naogostei`);
+        const qtd_dislikes = document.querySelector(`#post-${ codigo_post } #qtd-dislikes-${ codigo_post }`);
+        const lista_dislikes = JSON.parse(localStorage.getItem("lista_dislikes") || "[]");
+        
+
+        if (lista_likes.includes(codigo_post)) {
+
+            icone_gostei.src = "icones/interacao_shitpost_icons/icone-gostei.png";
+            qtd_likes.textContent = Number(qtd_likes.textContent) - 1;
+
+            removerElementoPorValor(lista_likes, codigo_post);
+
+        } else {
+            
+            icone_gostei.src = "icones/interacao_shitpost_icons/icone-gostei-press.png";
+            qtd_likes.textContent = Number(qtd_likes.textContent) + 1;
+            lista_likes.push(codigo_post);
+
+            /*se botão de dislike estiver marcado*/
+            if (lista_dislikes.includes(codigo_post)) {
+                icone_naogostei.src = "icones/interacao_shitpost_icons/icone-naogostei.png";
+                qtd_dislikes.textContent = Number(qtd_dislikes.textContent) - 1;
+                removerElementoPorValor(lista_dislikes, codigo_post);
+            }
+        }
+    
+        localStorage.setItem("lista_likes", JSON.stringify(lista_likes));
+        localStorage.setItem("lista_dislikes", JSON.stringify(lista_dislikes));
+    });
+}
+
+
+/*dar dislike*/
+function dislikeEvento (feed) {
+    feed.addEventListener("click", (event) => {
+        const botao_naogostei = event.target.closest(".botao-naogostei");
+
+        if (!botao_naogostei) return;
+
+        /*dados importantes do próprio botão de dislike*/
+        const codigo_post = botao_naogostei.id.slice(8);
+        const icone_naogostei = botao_naogostei.querySelector(".icone-naogostei");
+        const qtd_dislikes = botao_naogostei.querySelector(`#qtd-dislikes-${ codigo_post }`);
+        const lista_dislikes = JSON.parse(localStorage.getItem("lista_dislikes") || "[]");
+
+        /*dados do botão like*/
+        const icone_gostei = document.querySelector(`#post-${ codigo_post } .icone-gostei`);
+        const qtd_likes = document.querySelector(`#post-${ codigo_post } #qtd-likes-${ codigo_post }`);
+        const lista_likes = JSON.parse(localStorage.getItem("lista_likes") || "[]");
+
+        if (lista_dislikes.includes(codigo_post)) {
+
+            icone_naogostei.src = "icones/interacao_shitpost_icons/icone-naogostei.png";
+            qtd_dislikes.textContent = Number(qtd_dislikes.textContent) - 1;
+
+            removerElementoPorValor(lista_dislikes, codigo_post);
+
+        } else {
+
+            icone_naogostei.src = "icones/interacao_shitpost_icons/icone-naogostei-press.png";
+            qtd_dislikes.textContent = Number(qtd_dislikes.textContent) + 1;
+            lista_dislikes.push(codigo_post);
+
+            /*se botão de like estiver marcado*/
+            if (lista_likes.includes(codigo_post)) {
+                icone_gostei.src = "icones/interacao_shitpost_icons/icone-gostei.png";
+                qtd_likes.textContent = Number(qtd_likes.textContent) - 1;
+                removerElementoPorValor(lista_likes, codigo_post);
+            }
+        }
+
+        localStorage.setItem("lista_dislikes", JSON.stringify(lista_dislikes));
+        localStorage.setItem("lista_likes", JSON.stringify(lista_likes));
+    });
+}
+
+
+function removerElementoPorValor(array, elemento) {
+    const indice = array.indexOf(elemento);
+    if (indice > -1) {
+        array.splice(indice, 1);
+    }
+    return array;
+}

--- a/MediaVirtu/src/javascript/main.js
+++ b/MediaVirtu/src/javascript/main.js
@@ -2,15 +2,18 @@ import cabecalho from "./cabecalho.js"
 import barrasNavegacaoLateral from "./barras_navegacao_lateral.js"
 import pagina from "./corpo_principal.js"
 import banco_posts from "../data/shitposts.json" assert { type: "json" };
+import addLikesDislikesEventos from "./likes_dislikes.js"
 
 
 localStorage.setItem("banco_posts", JSON.stringify(banco_posts));
 
 localStorage.setItem("pagina_atual", "Inicio");
 
-const root = document.querySelector("#root");
+if (!localStorage.getItem("lista_likes")) localStorage.setItem("lista_likes", []);
 
-console.log(localStorage.getItem("banco_posts"))
+if (!localStorage.getItem("lista_dislikes")) localStorage.setItem("lista_dislikes", []);
+
+const root = document.querySelector("#root");
 
 
 function inicializar () {
@@ -22,6 +25,7 @@ function inicializar () {
     
     add_conteudo()
     eventosBarrasNavegacaoLateral();
+    addLikesDislikesEventos()
 }
 
 inicializar();

--- a/MediaVirtu/src/javascript/shitposts.js
+++ b/MediaVirtu/src/javascript/shitposts.js
@@ -1,6 +1,6 @@
 import tresPontinhos from "./tresPontinhos.js";
 
-export default function shitpost (nome_autor, foto_perfil_autor, tempo_postagem, conteudo_texto, lista_imagens = [], qtd_likes = 0, qtd_dislikes = 0) {
+export default function shitpost (nome_autor, foto_perfil_autor, tempo_postagem, conteudo_texto, lista_imagens = [], qtd_likes, qtd_dislikes, codigo_post = "xxxxxxxxxx") {
 
     const texto = conteudo_texto.length > 0 ?
     `<div class = "conteudo-shitpost">
@@ -15,7 +15,7 @@ export default function shitpost (nome_autor, foto_perfil_autor, tempo_postagem,
     : '';
 
     return `
-    <section class="bloco bloco-shitpost">
+    <section id = "post-${ codigo_post }" class="bloco bloco-shitpost">
         <div class = "topo-shitpost">
             <div class="autor">
                 <img src="${ foto_perfil_autor }" alt="" class="foto-perfil">
@@ -31,8 +31,8 @@ export default function shitpost (nome_autor, foto_perfil_autor, tempo_postagem,
             ${ imgs }
         </div>
         <div class = "painel-interacao-shitpost">
-            ${ gostei(nome_autor, qtd_likes) }
-            ${ naoGostei(nome_autor, qtd_dislikes) }
+            ${ gostei(qtd_likes, codigo_post) }
+            ${ naoGostei(qtd_dislikes, codigo_post) }
             ${ comentarios(nome_autor) }
         </div>
     </section>
@@ -41,24 +41,32 @@ export default function shitpost (nome_autor, foto_perfil_autor, tempo_postagem,
 
 
 
-function gostei (autor = "ninguem", qtd_likes = 0) {
+function gostei (qtd_likes = 0, codigo) {
+    const lista_likes = JSON.parse(localStorage.getItem("lista_likes") || "[]");
+    
+    const situacao_botao = lista_likes.includes(codigo) ? "-press" : "";
+    qtd_likes = lista_likes.includes(codigo) ? qtd_likes + 1 : qtd_likes;
 
     return `
-        <a class = "botao-gostei" href = "">
-            <img class = "icone-gostei" src = "icones/interacao_shitpost_icons/icone-gostei.png" alt = "gostei">
-            <p id = "gostei-shitpost-${ autor }">${ qtd_likes }</p>
+        <a id = "like-${ codigo }" class = "botao-gostei" href = "#a">
+            <img class = "icone-gostei" src = "icones/interacao_shitpost_icons/icone-gostei${ situacao_botao }.png" alt = "gostei">
+            <p id = "qtd-likes-${ codigo }">${ qtd_likes }</p>
         </a>
     `
 }
 
 
 
-function naoGostei (autor = "ninguem", qtd_dislikes = 0) {
+function naoGostei (qtd_dislikes = 0, codigo) {
+    const lista_dislikes = JSON.parse(localStorage.getItem("lista_dislikes") || "[]");
+
+    const situacao_botao = lista_dislikes.includes(codigo) ? "-press" : "";
+    qtd_dislikes = lista_dislikes.includes(codigo) ? qtd_dislikes + 1 : qtd_dislikes;
 
     return `
-        <a class = "botao-naogostei" href = "">
-            <img class = "icone-naogostei" src = "icones/interacao_shitpost_icons/icone-naogostei.png" alt = "nao-gostei">
-            <p id = "naogostei-shitpost-${ autor }">${ qtd_dislikes }</p>
+        <a id = "dislike-${ codigo }" class = "botao-naogostei" href = "#a">
+            <img class = "icone-naogostei" src = "icones/interacao_shitpost_icons/icone-naogostei${ situacao_botao }.png" alt = "nao-gostei">
+            <p id = "qtd-dislikes-${ codigo }">${ qtd_dislikes }</p>
         </a>
     `
 }


### PR DESCRIPTION
 Foi adicionado toda a lógica dos botões de like e deslike de cada shipots. Foi adicionado os arquivos:

 - likes_dislikes.js que adiciona evento aos botões de like e deslike de todos os posts da aplicação, além de ter a lógica de que, no caso de um dos botões já estarem ativados, e o usuário ativar outro, o primeiro será desativado automáticamente e, seu valor será decrementado.;
 - gerador_aleatorio.js que adiciona um gerador de código aleatório, utilizado para criar o id de cada post;

 Além dos arquivos adicionados, foram alterados os arquivos abaixo:

 - shitposts.json que foi adicionado um id para cada shitpost;
 - inicio.js foi modificado para passar como parâmero para a função construtora de shitposts o id do post a ser construido;
 - shitpost.js que foi alterado para, além de receber o id do post a ser construido, construir o html dos botões  de like e deslike em relação ao que está armazenado no localStorage;
 - main.js foi alterada para ativar os eventos dos botões de like e deslike... E para alterar a forma como que as listas de like e deslike, armazenadas no localStorage, são declaradas. Agora, caso as listas já existam, o main.js não vai reatribuir uma lista vazia às chaves listas_like e listas_dislike, no localStorage, evitando que esses dados se percam ao atualizar a página.