### PR TITLE
feature/adiciona usuarios

### DIFF
--- a/MediaVirtu/src/data/usuarios.json
+++ b/MediaVirtu/src/data/usuarios.json
@@ -1,0 +1,14 @@
+{
+    "Adm_Supremo" : {
+        
+        "nome" : "Adm_Supremo",
+
+        "foto_perfil" : "",
+
+        "senha" : "*************",
+
+        "likes" : [],
+
+        "dislikes" : []
+    }
+}

--- a/MediaVirtu/src/estilos/shitpost.css
+++ b/MediaVirtu/src/estilos/shitpost.css
@@ -119,6 +119,9 @@
     text-decoration: none;
     gap: 0.5em;
     width: 40px;
+    background: none;
+    border: none;
+    cursor: pointer;
 }
 
 .icone-gostei, .icone-naogostei, .icone-comentarios {

--- a/MediaVirtu/src/javascript/eventos/likes_dislikes_evento.js
+++ b/MediaVirtu/src/javascript/eventos/likes_dislikes_evento.js
@@ -8,45 +8,59 @@ export default function addLikesDislikesEventos () {
 /*dar like*/
 function likeEvento (feed) {
     feed.addEventListener("click", (event) => {
-        const botao_gostei = event.target.closest(".botao-gostei");
-        
+        const botao_gostei = event.target.closest(".botao-gostei");        
         if (!botao_gostei) return;
+
+        const usuario_atual = localStorage.getItem("usuario_atual");
+        if (!usuario_atual) return;
+
+        /*banco de usuarios e posts*/
+        const banco_usuarios = JSON.parse(localStorage.getItem("banco_usuarios"));
+        const banco_posts = JSON.parse(localStorage.getItem("banco_posts"));
         
         /*dados importantes do próprio botão de like*/
         const codigo_post = botao_gostei.id.slice(5);
+
         const icone_gostei = botao_gostei.querySelector(`.icone-gostei`);
         const qtd_likes = botao_gostei.querySelector(`#qtd-likes-${ codigo_post }`);
-        const lista_likes = JSON.parse(localStorage.getItem("lista_likes") || "[]");
 
         /*dados do botão de dislike*/
         const icone_naogostei = document.querySelector(`#post-${ codigo_post } .icone-naogostei`);
         const qtd_dislikes = document.querySelector(`#post-${ codigo_post } #qtd-dislikes-${ codigo_post }`);
-        const lista_dislikes = JSON.parse(localStorage.getItem("lista_dislikes") || "[]");
         
 
-        if (lista_likes.includes(codigo_post)) {
+        if (banco_usuarios[usuario_atual]["likes"].includes(codigo_post)) {
 
             icone_gostei.src = "icones/interacao_shitpost_icons/icone-gostei.png";
             qtd_likes.textContent = Number(qtd_likes.textContent) - 1;
 
-            removerElementoPorValor(lista_likes, codigo_post);
+            banco_usuarios[usuario_atual]["likes"] = removerElementoPorValor(banco_usuarios[usuario_atual]["likes"], codigo_post);
+
+            const post = banco_posts.find(p => String(p.codigo_post) === String(codigo_post));
+            if (post) post.likes = Number(post.likes) - 1;
 
         } else {
             
             icone_gostei.src = "icones/interacao_shitpost_icons/icone-gostei-press.png";
             qtd_likes.textContent = Number(qtd_likes.textContent) + 1;
-            lista_likes.push(codigo_post);
+            banco_usuarios[usuario_atual]["likes"].push(codigo_post);
+
+            const post = banco_posts.find(p => String(p.codigo_post) === String(codigo_post));
+            if (post) post.likes = Number(post.likes) + 1;
 
             /*se botão de dislike estiver marcado*/
-            if (lista_dislikes.includes(codigo_post)) {
+            if (banco_usuarios[usuario_atual]["dislikes"].includes(codigo_post)) {
                 icone_naogostei.src = "icones/interacao_shitpost_icons/icone-naogostei.png";
                 qtd_dislikes.textContent = Number(qtd_dislikes.textContent) - 1;
-                removerElementoPorValor(lista_dislikes, codigo_post);
+                banco_usuarios[usuario_atual]["dislikes"] = removerElementoPorValor(banco_usuarios[usuario_atual]["dislikes"], codigo_post);
+
+                const post = banco_posts.find(p => String(p.codigo_post) === String(codigo_post));
+                if (post) post.dislikes = Number(post.dislikes) - 1;
             }
-        }
-    
-        localStorage.setItem("lista_likes", JSON.stringify(lista_likes));
-        localStorage.setItem("lista_dislikes", JSON.stringify(lista_dislikes));
+        }   
+        
+        localStorage.setItem("banco_usuarios", JSON.stringify(banco_usuarios));
+        localStorage.setItem("banco_posts", JSON.stringify(banco_posts));
     });
 }
 
@@ -55,43 +69,57 @@ function likeEvento (feed) {
 function dislikeEvento (feed) {
     feed.addEventListener("click", (event) => {
         const botao_naogostei = event.target.closest(".botao-naogostei");
-
         if (!botao_naogostei) return;
+
+        const usuario_atual = localStorage.getItem("usuario_atual");
+        if (!usuario_atual) return;
+
+        /*banco de usuarios e posts*/
+        const banco_usuarios = JSON.parse(localStorage.getItem("banco_usuarios"));
+        const banco_posts = JSON.parse(localStorage.getItem("banco_posts"));
 
         /*dados importantes do próprio botão de dislike*/
         const codigo_post = botao_naogostei.id.slice(8);
+        
         const icone_naogostei = botao_naogostei.querySelector(".icone-naogostei");
         const qtd_dislikes = botao_naogostei.querySelector(`#qtd-dislikes-${ codigo_post }`);
-        const lista_dislikes = JSON.parse(localStorage.getItem("lista_dislikes") || "[]");
 
         /*dados do botão like*/
         const icone_gostei = document.querySelector(`#post-${ codigo_post } .icone-gostei`);
         const qtd_likes = document.querySelector(`#post-${ codigo_post } #qtd-likes-${ codigo_post }`);
-        const lista_likes = JSON.parse(localStorage.getItem("lista_likes") || "[]");
 
-        if (lista_dislikes.includes(codigo_post)) {
+        if (banco_usuarios[usuario_atual]["dislikes"].includes(codigo_post)) {
 
             icone_naogostei.src = "icones/interacao_shitpost_icons/icone-naogostei.png";
             qtd_dislikes.textContent = Number(qtd_dislikes.textContent) - 1;
 
-            removerElementoPorValor(lista_dislikes, codigo_post);
+            banco_usuarios[usuario_atual]["dislikes"] = removerElementoPorValor(banco_usuarios[usuario_atual]["dislikes"], codigo_post);
+
+            const post = banco_posts.find(p => String(p.codigo_post) === String(codigo_post));
+            if (post) post.dislikes = Number(post.dislikes) - 1;
 
         } else {
 
             icone_naogostei.src = "icones/interacao_shitpost_icons/icone-naogostei-press.png";
             qtd_dislikes.textContent = Number(qtd_dislikes.textContent) + 1;
-            lista_dislikes.push(codigo_post);
+            banco_usuarios[usuario_atual]["dislikes"].push(codigo_post);
+
+            const post = banco_posts.find(p => String(p.codigo_post) === String(codigo_post));
+            if (post) post.dislikes = Number(post.dislikes) + 1;
 
             /*se botão de like estiver marcado*/
-            if (lista_likes.includes(codigo_post)) {
+            if (banco_usuarios[usuario_atual]["likes"].includes(codigo_post)) {
                 icone_gostei.src = "icones/interacao_shitpost_icons/icone-gostei.png";
                 qtd_likes.textContent = Number(qtd_likes.textContent) - 1;
-                removerElementoPorValor(lista_likes, codigo_post);
+                banco_usuarios[usuario_atual]["likes"] = removerElementoPorValor(banco_usuarios[usuario_atual]["likes"], codigo_post);
+
+                const post = banco_posts.find(p => String(p.codigo_post) === String(codigo_post));
+                if (post) post.likes = Number(post.likes) - 1;
             }
         }
 
-        localStorage.setItem("lista_dislikes", JSON.stringify(lista_dislikes));
-        localStorage.setItem("lista_likes", JSON.stringify(lista_likes));
+        localStorage.setItem("banco_usuarios", JSON.stringify(banco_usuarios));
+        localStorage.setItem("banco_posts", JSON.stringify(banco_posts));
     });
 }
 

--- a/MediaVirtu/src/javascript/inicio/shitposts.js
+++ b/MediaVirtu/src/javascript/inicio/shitposts.js
@@ -46,32 +46,32 @@ export default function shitpost (nome_autor, foto_perfil_autor, tempo_postagem,
 
 
 function iconeGostei (qtd_likes = 0, codigo) {
-    const lista_likes = JSON.parse(localStorage.getItem("lista_likes") || "[]");
+    const banco_usuarios = JSON.parse(localStorage.getItem("banco_usuarios") || "{}");
+    const usuario_atual = localStorage.getItem("usuario_atual")
     
-    const situacao_botao = lista_likes.includes(codigo) ? "-press" : "";
-    qtd_likes = lista_likes.includes(codigo) ? qtd_likes + 1 : qtd_likes;
+    const situacao_botao = usuario_atual != "" && banco_usuarios[usuario_atual]["likes"].includes(codigo) ? "-press" : "";
 
     return `
-        <a id = "like-${ codigo }" class = "botao-gostei" href = "#a">
+        <button id = "like-${ codigo }" class = "botao-gostei">
             <img class = "icone-gostei" src = "icones/interacao_shitpost_icons/icone-gostei${ situacao_botao }.png" alt = "gostei">
             <p id = "qtd-likes-${ codigo }">${ qtd_likes }</p>
-        </a>
+        </button>
     `
 }
 
 
 
 function iconeNaoGostei (qtd_dislikes = 0, codigo) {
-    const lista_dislikes = JSON.parse(localStorage.getItem("lista_dislikes") || "[]");
+    const banco_usuarios = JSON.parse(localStorage.getItem("banco_usuarios") || "{}");
+    const usuario_atual = localStorage.getItem("usuario_atual");
 
-    const situacao_botao = lista_dislikes.includes(codigo) ? "-press" : "";
-    qtd_dislikes = lista_dislikes.includes(codigo) ? qtd_dislikes + 1 : qtd_dislikes;
+    const situacao_botao = usuario_atual != "" && banco_usuarios[usuario_atual]["dislikes"].includes(codigo) ? "-press" : "";
 
     return `
-        <a id = "dislike-${ codigo }" class = "botao-naogostei" href = "#a">
+        <button id = "dislike-${ codigo }" class = "botao-naogostei">
             <img class = "icone-naogostei" src = "icones/interacao_shitpost_icons/icone-naogostei${ situacao_botao }.png" alt = "nao-gostei">
             <p id = "qtd-dislikes-${ codigo }">${ qtd_dislikes }</p>
-        </a>
+        </button>
     `
 }
 
@@ -87,9 +87,9 @@ function iconeComentarios (codigo_post) {
     );
 
     return `
-        <a id = "comentarios-${ codigo_post }" class = "botao-comentarios" href = "#a">
+        <button id = "comentarios-${ codigo_post }" class = "botao-comentarios">
             <img class = "icone-comentarios" src = "icones/interacao_shitpost_icons/icone-comentarios.png" alt = "nao-gostei">
             <p id = "qtd-comentarios-shitpost-${ codigo_post }">${ qtd_comentarios }</p>
-        </a>
+        </button>
     `
 }

--- a/MediaVirtu/src/javascript/main.js
+++ b/MediaVirtu/src/javascript/main.js
@@ -4,13 +4,15 @@ import preloader from "./componentes_simples/preloader_construtor.js";
 import add_conteudo from "./add_conteudo.js";
 import ativaEventos from "./ativaEventos.js";
 import banco_posts from "../data/shitposts.json" assert { type: "json" };
+import banco_usuarios from "../data/usuarios.json" assert { type: "json" };
 import banco_comentarios from "../data/comentarios.json" assert { type: "json" };
 
 
-localStorage.setItem("banco_posts", JSON.stringify(banco_posts));
+if (!localStorage.getItem("banco_posts")) localStorage.setItem("banco_posts", JSON.stringify(banco_posts));
 
-if (!localStorage.getItem("lista_likes")) localStorage.setItem("lista_likes", []);
-if (!localStorage.getItem("lista_dislikes")) localStorage.setItem("lista_dislikes", []);
+if (!localStorage.getItem("banco_usuarios")) localStorage.setItem("banco_usuarios", JSON.stringify(banco_usuarios));
+if (!localStorage.getItem("usuario_atual")) localStorage.setItem("usuario_atual", banco_usuarios["Adm_Supremo"]["nome"] || "");
+
 if (!localStorage.getItem("banco_comentarios")) localStorage.setItem("banco_comentarios", JSON.stringify(banco_comentarios));
 
 localStorage.setItem("pagina_atual", "Inicio");


### PR DESCRIPTION
 Adiciona sistema de usuários, onde cada usuário poderá interagir com os shitposts, e seus dados ficarem salvos.
 Essa adição possibilitará a expansão do sistema para o uso de multiplas contas por dispositivo.
 Também possibilitará a implementação da funcionalidade do usuário poder comentar em um shitpost.

 foi adicionado o arquivo:

 - usuarios.json responsável por armazenar o usuário padrão/inicial;

 foram modificados os arquivos:

 - main.js para importar os bancos de shitposts, os bancos de comentários e o banco de usuário padrão;
 - shitposts.js para ler diretamente do banco de dados, as contagens de like e deslike de um post, e também buscar nos dados do usuário atual, se ele marcou o post específico com like/dislike;
 - likes_dislikes_evento.js foi modificado para alterar a lista de likes e dislikes do usuário atual, e alterar a contagem de likes e dislikes dos posts;
 - shitpost.css foi modificado para possibilitar a mudança dos botões de like/deslike/comentários, da tag <a> para a tag <button>. Essa mudança foi necessária para evitar possíveis bugs causados pelo redirecionamento que a tag <a> faz ao ser clicada, e o novo sistema de usuários.